### PR TITLE
feat: add option for whitelisting broken Apple devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Some software used by Apple devices send requests pretending to be a Facebook or
 iMessage, for example, does this to obtain link previews.
 If you want to allow this behavior and not block such requests, set this variable to `1`.
 
-Note: This setting, when enabled, is opening a hole in the fake bot detection
-which can be used by fake bots to bypass a protection provided by this plugin.
+Note: This setting, when enabled, opens a hole in the fake bot detection,
+which can be used by fake bots to bypass the protection provided by this plugin.
 
 Default value: 0
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ For full and up to date instructions for the different available plugin
 installation methods, refer to [How to Install a Plugin](https://coreruleset.org/docs/concepts/plugins/#how-to-install-a-plugin)
 in the official CRS documentation.
 
+## Plugin configuration
+
+All settings can be done in file `plugins/fake-bot-config.conf`.
+
+### tx.fake-bot-plugin_whitelist_broken_apple_devices
+
+Some software used by Apple devices (for example iMessage) are doing requests
+to web pages while pretending to be a Facebookbot and Twitterbot. If you want to
+allow this behavior and not block such requests, set this setting to `1`.
+
+Note: This setting, when enabled, is opening a hole in the fake bot detection
+which can be used by fake bots to bypass a protection provided by this plugin.
+
+Default value: 0
+
 ## Testing
 
 After installation, plugin should be tested, for example, using:  

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ in the official CRS documentation.
 
 ## Plugin configuration
 
-All settings can be done in file `plugins/fake-bot-config.conf`.
+The settings for this plugin reside in `plugins/fake-bot-config.conf`.
 
 ### tx.fake-bot-plugin_whitelist_broken_apple_devices
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ The settings for this plugin reside in `plugins/fake-bot-config.conf`.
 
 ### tx.fake-bot-plugin_whitelist_broken_apple_devices
 
-Some software used by Apple devices (for example iMessage) are doing requests
-to web pages while pretending to be a Facebookbot and Twitterbot. If you want to
-allow this behavior and not block such requests, set this setting to `1`.
+Some software used by Apple devices send requests pretending to be a Facebook or Twitter (X) bot.
+iMessage, for example, does this to obtain link previews.
+If you want to allow this behavior and not block such requests, set this variable to `1`.
 
 Note: This setting, when enabled, is opening a hole in the fake bot detection
 which can be used by fake bots to bypass a protection provided by this plugin.

--- a/plugins/fake-bot-after.conf
+++ b/plugins/fake-bot-after.conf
@@ -16,8 +16,20 @@
 # Documentation can be found here:
 # https://github.com/coreruleset/fake-bot-plugin
 
-SecRule REQUEST_HEADERS:User-Agent "@pm amazonbot applebot bingbot linkedinbot facebookbot facebookcatalog facebookexternalhit googlebot twitterbot" \
+SecRule TX:FAKE-BOT-PLUGIN_WHITELIST_BROKEN_APPLE_DEVICES "@streq 1" \
     "id:9504110,\
+    phase:1,\
+    t:none,\
+    msg:'Broken Apple device detected from %{REMOTE_ADDR} - whitelisting',\
+    logdata:'Matched Data: REQUEST_HEADERS:User-Agent: %{REQUEST_HEADERS.User-Agent}',\
+    tag:'paranoia-level/1',\
+    ver:'fake-bot-plugin/1.0.0',\
+    skip:1,\
+    chain"
+    SecRule REQUEST_HEADERS:User-Agent "@endsWith facebookexternalhit/1.1 Facebot Twitterbot/1.0"
+
+SecRule REQUEST_HEADERS:User-Agent "@pm amazonbot applebot bingbot linkedinbot facebookbot facebookcatalog facebookexternalhit googlebot twitterbot" \
+    "id:9504120,\
     phase:1,\
     block,\
     capture,\

--- a/plugins/fake-bot-after.conf
+++ b/plugins/fake-bot-after.conf
@@ -19,8 +19,9 @@
 SecRule TX:FAKE-BOT-PLUGIN_WHITELIST_BROKEN_APPLE_DEVICES "@streq 1" \
     "id:9504110,\
     phase:1,\
+    pass,\
     t:none,\
-    msg:'Broken Apple device detected from %{REMOTE_ADDR} - whitelisting',\
+    msg:'Fake Bot Plugin: Broken Apple device detected from %{REMOTE_ADDR} - whitelisting',\
     logdata:'Matched Data: REQUEST_HEADERS:User-Agent: %{REQUEST_HEADERS.User-Agent}',\
     tag:'paranoia-level/1',\
     ver:'fake-bot-plugin/1.0.0',\
@@ -34,7 +35,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pm amazonbot applebot bingbot linkedinbot f
     block,\
     capture,\
     t:none,\
-    msg:'Fake bot detected: %{tx.fake-bot-plugin_bot_name}',\
+    msg:'Fake Bot Plugin: Detected fake %{tx.fake-bot-plugin_bot_name}.',\
     logdata:'Matched Data: %{TX.0} found within REQUEST_HEADERS:User-Agent: %{REQUEST_HEADERS.User-Agent}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/plugins/fake-bot-config.conf
+++ b/plugins/fake-bot-config.conf
@@ -41,3 +41,12 @@
 #   pass,\
 #   nolog,\
 #   setvar:'tx.fake-bot-plugin_enabled=0'"
+
+SecAction \
+ "id:9504020,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  ver:'fake-bot-plugin/1.0.0',\
+  setvar:'tx.fake-bot-plugin_whitelist_broken_apple_devices=0'"

--- a/tests/regression/fake-bot-plugin/9504120.yaml
+++ b/tests/regression/fake-bot-plugin/9504120.yaml
@@ -3,9 +3,9 @@ meta:
   author: "azurit"
   description: "Fake Bot Plugin"
   enabled: true
-  name: 9504110.yaml
+  name: 9504120.yaml
 tests:
-  - test_title: 9504110-1
+  - test_title: 9504120-1
     desc: Check that plugin is not blocking standard User-Agents
     stages:
       - stage:
@@ -20,8 +20,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            no_log_contains: id "9504110"
-  - test_title: 9504110-2
+            no_log_contains: id "9504120"
+  - test_title: 9504120-2
     desc: Check for blocking of fake Googlebot
     stages:
       - stage:
@@ -36,8 +36,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
-  - test_title: 9504110-3
+            log_contains: id "9504120"
+  - test_title: 9504120-3
     desc: Check for blocking of fake Facebookbot
     stages:
       - stage:
@@ -52,8 +52,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
-  - test_title: 9504110-4
+            log_contains: id "9504120"
+  - test_title: 9504120-4
     desc: Check for blocking of fake Bingbot
     stages:
       - stage:
@@ -68,8 +68,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
-  - test_title: 9504110-5
+            log_contains: id "9504120"
+  - test_title: 9504120-5
     desc: Check for blocking of fake Twitterbot
     stages:
       - stage:
@@ -84,8 +84,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
-  - test_title: 9504110-6
+            log_contains: id "9504120"
+  - test_title: 9504120-6
     desc: Check for blocking of fake Applebot
     stages:
       - stage:
@@ -100,8 +100,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
-  - test_title: 9504110-7
+            log_contains: id "9504120"
+  - test_title: 9504120-7
     desc: Check for blocking of fake LinkedInBot
     stages:
       - stage:
@@ -116,8 +116,8 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
-  - test_title: 9504110-8
+            log_contains: id "9504120"
+  - test_title: 9504120-8
     desc: Check for blocking of fake Amazonbot
     stages:
       - stage:
@@ -132,4 +132,4 @@ tests:
             version: HTTP/1.1
             uri: /get
           output:
-            log_contains: id "9504110"
+            log_contains: id "9504120"


### PR DESCRIPTION
Some of the Apple software for macOS and iOS (for example iMessage) is doing requests using `User-Agent` header similar to this:
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.4 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.4 facebookexternalhit/1.1 Facebot Twitterbot/1.0`

This PR adds an option to whitelist such requests (defaults to off).