### PR TITLE
feat: Support for GoogleOther* bots

### DIFF
--- a/plugins/fake-bot-after.conf
+++ b/plugins/fake-bot-after.conf
@@ -29,7 +29,7 @@ SecRule TX:FAKE-BOT-PLUGIN_WHITELIST_BROKEN_APPLE_DEVICES "@streq 1" \
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith facebookexternalhit/1.1 Facebot Twitterbot/1.0"
 
-SecRule REQUEST_HEADERS:User-Agent "@pm amazonbot applebot bingbot linkedinbot facebookbot facebookcatalog googlebot twitterbot" \
+SecRule REQUEST_HEADERS:User-Agent "@pm amazonbot applebot bingbot linkedinbot facebookbot facebookcatalog googlebot googleother twitterbot" \
     "id:9504120,\
     phase:1,\
     block,\

--- a/plugins/fake-bot.lua
+++ b/plugins/fake-bot.lua
@@ -48,7 +48,7 @@ function main(matched_bot)
 		m.log(2, "Fake Bot Plugin ERROR: LuaSocket library not installed, please install it or disable this plugin.")
 		return nil
 	end
-	if matched_bot == "googlebot" then
+	if matched_bot == "googlebot" or matched_bot == "googleother" then
 		-- https://developers.google.com/search/docs/advanced/crawling/verifying-googlebot
 		bot_domains = {".googlebot.com", ".google.com"}
 		bot_name = "Googlebot"

--- a/tests/regression/fake-bot-plugin/9504120.yaml
+++ b/tests/regression/fake-bot-plugin/9504120.yaml
@@ -116,3 +116,19 @@ tests:
         output:
           log:
             expect_ids: [9504120]
+  - test_id: 8
+    desc: Check for blocking of fake GoogleOther
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Mobile Safari/537.36 (compatible; GoogleOther)"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          method: GET
+          version: HTTP/1.1
+          uri: /get
+        output:
+          log:
+            expect_ids: [9504120]


### PR DESCRIPTION
Adding support for `GoogleOther*` bot as i'm seeing more and more of them:

`Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Mobile Safari/537.36 (compatible; GoogleOther)`

https://developers.google.com/crawling/docs/crawlers-fetchers/google-common-crawlers#googleother